### PR TITLE
ACPI parameter support and cleanup

### DIFF
--- a/exe/ectest.cpp
+++ b/exe/ectest.cpp
@@ -36,7 +36,6 @@ _Analysis_mode_(_Analysis_code_type_user_code_)
 #include <Devpkey.h>
 #include <Acpiioct.h>
 #include <devioctl.h>
-#include <Objbase.h>
 #include "..\inc\ectest.h"
 
 extern "C" {
@@ -120,7 +119,18 @@ int DumpAcpi(ACPI_EVAL_INPUT_BUFFER_COMPLEX_V1_EX *acpiinput )
     return ERROR_SUCCESS;
 }
 
-
+/*
+ * Function: BYTE ToHex
+ *
+ * Description:
+ * This function converts an ASCII character to corresponding hex value or returns 0 if invalid
+ *
+ * Parameters:
+ * c: Character to convert
+ *
+ * Return Value:
+ * BYTE value between 0 and 15 if valid; 0 otherwise.
+ */
 BYTE ToHex(char c)
 {
     if(c >= '0' && c <= '9') return c - '0';

--- a/exe/ectest_app.vcxproj
+++ b/exe/ectest_app.vcxproj
@@ -89,7 +89,8 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);mincore.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories);..\lib\$(platform)\Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies);mincore.lib;eclib.lib</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);$(SDK_INC_PATH)</AdditionalIncludeDirectories>

--- a/inc/eclib.h
+++ b/inc/eclib.h
@@ -32,8 +32,8 @@ ECLIB_API int GetKMDFDriverHandle(
 );
 
 ECLIB_API int EvaluateAcpi(
-    _In_ const char* eval,
-    _In_ size_t eval_len,
+    _In_ void* acpi_input,
+    _In_ size_t input_len,
     _Out_ BYTE* buffer,
     _In_ size_t* buf_len
 );

--- a/lib/eclib.c
+++ b/lib/eclib.c
@@ -161,8 +161,8 @@ int GetKMDFDriverHandle(
  * Description:
  *   Evaluates an ACPI method on a specified device and returns the result.
  * Parameters:
- *   const char* eval     - ACPI method name.
- *   size_t eval_len      - Length of the method name.
+ *   void* acpi_input     - ACPI_EVAL_INPUT_xxxx structure pointer passed through
+ *   size_t input_len     - Length of input structure
  *   BYTE* buffer         - Output buffer for the result.
  *   size_t* buf_len      - Input: size of buffer; Output: bytes returned.
  * Return Value:
@@ -170,22 +170,16 @@ int GetKMDFDriverHandle(
  */
 ECLIB_API
 int EvaluateAcpi(
-    _In_ const char* eval,
-    _In_ size_t eval_len,
+    _In_ void* acpi_input,
+    _In_ size_t input_len,
     _Out_ BYTE* buffer,
     _In_ size_t* buf_len
 )
 {
     WCHAR pathbuf[MAX_DEVPATH_LENGTH];
-    ACPI_EVAL_INPUT_BUFFER_V1_EX InputBuffer = { 0 };
     ULONG bytesReturned;
 
-    memset(buffer, 0, *buf_len);
-    InputBuffer.Signature = ACPI_EVAL_INPUT_BUFFER_SIGNATURE_EX;
-    strncpy_s(InputBuffer.MethodName, sizeof(InputBuffer.MethodName), eval, eval_len);
-
     // Look up handle to ACPI entry
-
     wchar_t* dpath = GetGUIDPath(GUID_DEVCLASS_ECTEST, L"ETST0001", pathbuf, sizeof(pathbuf));
     if (dpath == NULL) {
         return ERROR_INVALID_PARAMETER;
@@ -202,8 +196,8 @@ int EvaluateAcpi(
     if (hDevice != INVALID_HANDLE_VALUE) {
         if( DeviceIoControl(hDevice,
             (DWORD)IOCTL_ACPI_EVAL_METHOD_EX,
-            &InputBuffer,
-            sizeof(InputBuffer),
+            acpi_input,
+            (DWORD)input_len,
             buffer,
             (DWORD)*buf_len,
             &bytesReturned,

--- a/rust/src/battery.rs
+++ b/rust/src/battery.rs
@@ -107,7 +107,7 @@ impl Battery {
         let bat_status = Self::get_bst();
         //let bat_info = Self::get_bix();
         //let bat_percent = (bat_status.capacity / bat_info.design_capacity) * 100;
-        let bat_percent = bat_status.capacity / 120; // Use fake values till BIX is available
+        let bat_percent = bat_status.capacity / 82; // Use fake values till BIX is available
 
         let status_title = Self::title_block("Battery Status");
         Paragraph::new(Self::create_status(area, bat_status))
@@ -149,7 +149,7 @@ impl Battery {
     }
     */
 
-    fn title_block(title: &str) -> Block {
+    fn title_block(title: &str) -> Block<'_> {
         let title = Line::from(title);
         Block::new()
             .borders(Borders::NONE)
@@ -161,8 +161,8 @@ impl Battery {
     fn create_status(_area: Rect, status: BstData) -> Vec<Line<'static>> {
         vec![
             Line::raw(format!("State:               {:?}", status.state)),
-            Line::raw(format!("Present Rate:        {:?}mAh", status.rate)),
-            Line::raw(format!("Remaining Capacity:  {:?}mAh", status.capacity)),
+            Line::raw(format!("Present Rate:        {:?}mWh", status.rate)),
+            Line::raw(format!("Remaining Capacity:  {:?}mWh", status.capacity)),
             Line::raw(format!("Present Voltage:     {:?}mV", status.voltage)),
         ]
     }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -27,8 +27,7 @@ use strum::{Display, EnumIter, FromRepr, IntoEnumIterator};
 fn main() -> Result<()> {
     color_eyre::install()?;
     let terminal = ratatui::init();
-    let app_result = App::default().run(terminal);
-    app_result
+    App::default().run(terminal)
 }
 
 /// The main application which holds the state and logic of the application.

--- a/rust/src/rtc.rs
+++ b/rust/src/rtc.rs
@@ -18,7 +18,7 @@ impl Rtc {
     }
 }
 
-fn title_block(title: &str) -> Block {
+fn title_block(title: &str) -> Block<'_> {
     let title = Line::from(title);
     Block::new()
         .borders(Borders::NONE)

--- a/rust/src/thermal.rs
+++ b/rust/src/thermal.rs
@@ -18,7 +18,7 @@ impl Thermal {
     }
 }
 
-fn title_block(title: &str) -> Block {
+fn title_block(title: &str) -> Block<'_> {
     let title = Line::from(title);
     Block::new()
         .borders(Borders::NONE)

--- a/rust/src/ucsi.rs
+++ b/rust/src/ucsi.rs
@@ -18,7 +18,7 @@ impl Ucsi {
     }
 }
 
-fn title_block(title: &str) -> Block {
+fn title_block(title: &str) -> Block<'_> {
     let title = Line::from(title);
     Block::new()
         .borders(Borders::NONE)


### PR DESCRIPTION
Add support to pass ACPI input parameters down to KMDF driver from both rust application and the test app.
Clean up some clippy warnings.
Validated functionality of both ectest.exe, ectest.sys and ec_demo.exe on target device.